### PR TITLE
add a new functionality to support a specific ldap CA certificate (when the certificate is auto-signed or unknown)

### DIFF
--- a/databases/user/ldap.ts
+++ b/databases/user/ldap.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import * as properties from '../../properties/properties.js';
 import * as fileUtils from '../../services/fileUtils.js';
 import { UserNotFoundError } from '../../services/errors.js';
@@ -26,12 +27,20 @@ export default class LdapUserDb implements UserDb<StandardUserData<InternalUser>
         errorIfMultiTenantContext();
 
         logger.info(fileUtils.getFileNameFromUrl(import.meta.url) + ' Initializing ldap connection');
-        this.client = new Client({
+        const clientOptions = {
             url: this.ldapProperties.uri,
             timeout: this.ldapProperties.timeout,
             connectTimeout: this.ldapProperties.connectTimeout,
             autoRebind: true,
-        });
+        };
+
+        if (this.ldapProperties.caCertificate) {
+            clientOptions.tlsOptions = {
+                ca: [fs.readFileSync(this.ldapProperties.caCertificate)],
+            };
+        }
+
+        this.client = new Client(clientOptions);
         await this.client.bind(this.ldapProperties.adminDn, this.ldapProperties.password)
         logger.info(fileUtils.getFileNameFromUrl(import.meta.url) + ' Ldap connection Initialized');
     }

--- a/properties/esup.json
+++ b/properties/esup.json
@@ -34,6 +34,8 @@
     },
     "ldap": {
         "uri": "ldap://127.0.0.1",
+        "#how_to_caCertificate": "CA or certificate path to handle the certificate validation with ldaps, usefull when the certificate is auto-signed or unknown (for example: /etc/pki/tls/certs/cert.crt)",
+        "#caCertificate": "",
         "#how_to_timeout": "Milliseconds client should let operations live for before timing out (Default: Infinity)",
         "timeout": 0,
         "#how_to_connectTimeout": "Milliseconds client should wait before timing out on TCP connections (Default: OS default)",


### PR DESCRIPTION
add a how_to for the specific ldap CA certificate functionality